### PR TITLE
Change Datenschutzerklaerung and Mitgliedsantrag according to current regulations

### DIFF
--- a/latex/datenschutzerklaerung.tex
+++ b/latex/datenschutzerklaerung.tex
@@ -21,7 +21,7 @@
 
 \title{Datenschutzerklärung gemäß DSGVO Art.~13\\
     für die Mitgliederverwaltung des foobar~e.V.}
-\date{Stand 2018-05-25}
+\date{Stand 2022-02-08}
 
 \begin{document}
 \maketitle
@@ -81,25 +81,30 @@ Rechtsgrundlage für die Verarbeitung ist DSGVO Art.~6~(1b), da die
 Vereinsmitgliedschaft rechtlich gesehen ein Vertrag zwischen Mitglied
 und Verein ist.
 
+\section*{(2a) Erforderliche Daten}
 
-\section*{(1d) Berechtigte Interessen}
-
-Entfällt, da die Daten nicht auf Grundlage von Art.~6~(1f)
-"`berechtigte Interessen"' erhoben werden.
-
-
-\section*{(1e) und (1f) Weitergabe}
-
-Entfallen, da die erhobenen Daten nicht an Dritte weitergegeben werden.
+Name und Postanschrift sind erforderlich zur Identifikation, für die
+Benachrichtigung des Mitglieds über Versammlungen und für sonstige
+formale Vereinsangelegenheiten wie zum Beispiel Satzungsänderungen.
+%
+Die Informationen zum Beitragshöhe und -turnus sind erforderlich
+für die Prüfung, ob Mitgliedsbeiträge bezahlt wurden.
 
 
-\section*{(2a) Dauer der Speicherung}
+\section*{(2b) Freiwillige Daten}
 
-Die Löschung oder Sperrung erfolgt in einem angemessenen Zeitraum nach
-Ende der vorgeschriebenen Aufbewahrungsfristen.
+Die Angabe einer E-Mail-Adresse ist nicht unbedingt erforderlich.
+Für eine direkte Kommunikation innerhalb des Vereins ist es aber ratsam eine solche Adresse anzugeben.
+Es kann angegeben werden, dass ausschließlich E-Mail-Kommunikation gewünscht wird.
+In diesem Fall findet jegliche Kommunikation per E-Mail statt.
+%
+Die GPG-Schlüssel-Id ist nicht erforderlich, kann aber freiwillig angegeben werden.
+Diese wird dazu verwendet, die Kommunikation via E-Mail für das Mitglied zu verschlüsseln.
+%
+Wir verarbeiten diese Daten auf Grundlage von DSGVO Art.~6~(1a)
 
 
-\section*{(2b) Rechte}
+\section*{(2d) Rechte}
 
 Es bestehen Rechte auf Auskunft (siehe Art.~15),
 Berichtigung (Art.~16),
@@ -107,42 +112,17 @@ Löschung (Art.~17),
 Einschränkung der Verarbeitung von Daten (Art.~18)
 sowie der Übertragung von Daten (Art.~20).
 
+Außerdem besteht das Recht auf Widerruf gegen die Verarbeitung der freiwillig angegebenen Email-Adresse (Art.~7).
 
-\section*{(2c) Widerruf der Einwilligung}
+Es besteht kein Recht auf Widerspruch gegen die Verarbeitung erforderlicher Daten,
+da DSGVO Art.~6~(1e und 1f) nicht einschlägig sind.
 
-Entfällt, da die Daten nicht auf der Rechtsgrundlage einer
-Einwilligung nach Art.~6~(1a) oder Art.~9~(2a) verarbeitet werden.
+\section*{(2e) Beschwerderecht}
 
-
-\section*{(2d) Beschwerderecht}
-
-Es besteht das Recht, sich bei der Aufsichtsbehörde zu beschweren:
-
-\medskip
-Landesbeauftragte für Datenschutz und Informationsfreiheit Nordrhein-Westfalen\\
-Helga Block\\
-Postfach 20\,04\,44\\
-40102 Düsseldorf\\ 
-\url{https://www.ldi.nrw.de/}
-
-
-\section*{(2e) Erforderliche Daten}
-
-Name und Postanschrift sind erforderlich zur Identifikation, für die
-Benachrichtigung des Mitglieds über Versammlungen und für sonstige
-formale Vereinsangelegenheiten wie zum Beispiel Satzungsänderungen.
-%
-Die Informationen zum Beitragshöhe und -turnus sind erforderlich
-für die Prüfung ob Mitgliedsbeiträge bezahlt wurden.
-%
-Die Emailadresse ist für die sonstige Kommunikation mit dem Mitglied
-erforderlich.
-%
-Die GPG-Schlüssel-Id ist nicht erforderlich.
-
-
-\section*{(2f) Automatisierte Entscheidungsfindung}
-
-Es findet keine automatisierte Entscheidungsfindung statt.
+Es besteht das Recht, eine Beschwerde bei der zuständigen Aufsichtsbehörde einzureichen.
+Das Beschwerderecht kann bei einer Aufsichtsbehörde in dem Mitgliedstaat
+des gewöhnlichen Aufenthaltsorts,
+des Arbeitsplatzes oder
+des Orts des mutmaßlichen Verstoßes geltend gemacht werden.
 
 \end{document}

--- a/latex/mitgliedsantrag.tex
+++ b/latex/mitgliedsantrag.tex
@@ -15,7 +15,7 @@
 \TextField[width=10cm,bordercolor=black]{Name\hfill}\\[3mm]
 \TextField[width=10cm,bordercolor=black]{Straße, Hausnummer\hfill}\\[3mm]
 \TextField[width=10cm,bordercolor=black]{Postleitzahl, Ort\hfill}\\[3mm]
-\TextField[width=10cm,bordercolor=black]{E-Mail\hfill}\\[3mm]
+\TextField[width=10cm,bordercolor=black]{E-Mail (freiwillig)\hfill}\\[3mm]
 \TextField[width=10cm,bordercolor=black]{Mitgliedsnummer (falls vorhanden)\hfill}
 
 \section*{Mitgliedschaft}


### PR DESCRIPTION
As current regulations by the LDI NRW require, the provision of an e-mail address has been made optional. 
This is due to the fact, that an e-mail address is not required by our Satzung in order to be part of the Vereinsleben. 

> See the bottom of page 21 of [LDI NRW - Datenschutz im Verein nach der DSGVO](https://www.ldi.nrw.de/mainmenu_Datenschutz/submenu_Datenschutzrecht/Inhalt/Vereine/Inhalt/Datenschutz-im-Verein-nach-der-Datenschutz-Grundverordnung/OH-Datenschutz-im-Verein-nach-der-DSGVO.pdf) for comparison.


As this change affects the rights of other members of the Verein, it is recommended to inform them of the new Datenschutzerklärung as soon as it is instated, as they gain the right to object against the usage of their e-mail address(es).

---

Apart from these changes, I restructured the declaration in order to have the explanation of applicable rights at the end of the document.

Also I deleted the following parts:

<table>
<tr>
	<th> Content
	<th> Reason for deletion
<tr>
	<td> Declaration of usage or rights which do not apply
	<td> In order to focus on what <i>is</i> applicable
<tr>
	<td> Saving period of data
	<td> As we do not state other than the regulatory saving periods
</table>

---

If you have any questions or require another solution regarding the e-mail issue, just let me know! 👍🏻 